### PR TITLE
Fury DShot

### DIFF
--- a/src/main/target/FURYF3/target.c
+++ b/src/main/target/FURYF3/target.c
@@ -21,17 +21,20 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM2,  IO_TAG(PB3),  TIM_Channel_2, TIM2_IRQn,               0, IOCFG_AF_PP, GPIO_AF_1 }, // PPM IN
-    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2 }, // SS1 - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
-    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2 }, // SS1 - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
 
-    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 }, // PWM4 - S1
-    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 }, // PWM5 - S2
-    { TIM17, IO_TAG(PB5),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP, GPIO_AF_10}, // PWM6 - S3
-    { TIM16, IO_TAG(PB4),  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM7 - S4
+    { TIM2,  IO_TAG(PB3),  TIM_Channel_2, TIM2_IRQn,               0, IOCFG_AF_PP, GPIO_AF_1, NULL, 0 }, // PPM IN
+    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2, NULL, 0 }, // SS1 - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
+    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2, NULL, 0 }, // SS1 - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
 
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_6 }, // GPIO TIMER - LED_STRIP
+    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2,  DMA1_Channel4, DMA1_CH4_HANDLER }, // PWM4 - S1
+    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2,  DMA1_Channel1, DMA1_CH1_HANDLER }, // PWM5 - S2
+    { TIM17, IO_TAG(PB5),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP, GPIO_AF_10, DMA1_Channel7, DMA1_CH7_HANDLER }, // PWM6 - S3
+    { TIM16, IO_TAG(PB4),  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP, GPIO_AF_1,  DMA1_Channel3, DMA1_CH3_HANDLER }, // PWM7 - S4
+
+    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_6, NULL, 0 }, // GPIO TIMER - LED_STRIP
+
 };
 

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -167,6 +167,8 @@
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
+#define USE_DSHOT
+
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff

--- a/src/main/target/FURYF3/target.mk
+++ b/src/main/target/FURYF3/target.mk
@@ -8,5 +8,6 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu6000.c \
             drivers/accgyro_mpu6500.c \
             drivers/accgyro_spi_mpu6500.c \
-            drivers/accgyro_spi_icm20689.c
+            drivers/accgyro_spi_icm20689.c \
+            drivers/pwm_output_stm32f3xx.c
 

--- a/src/main/target/FURYF4/target.c
+++ b/src/main/target/FURYF4/target.c
@@ -19,16 +19,17 @@
 
 #include <platform.h>
 #include "drivers/io.h"
-
+#include "drivers/dma.h"
 #include "drivers/timer.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM8, IO_TAG(PC9), TIM_Channel_4, TIM8_CC_IRQn,       0, IOCFG_AF_PP, GPIO_AF_TIM8 },          // PPM_IN
 
-    { TIM9, IO_TAG(PA3), TIM_Channel_2, TIM1_BRK_TIM9_IRQn, 1, IOCFG_AF_PP, GPIO_AF_TIM9 },          // S1_OUT
-    { TIM3, IO_TAG(PB0), TIM_Channel_3, TIM3_IRQn,          1, IOCFG_AF_PP, GPIO_AF_TIM3 },          // S2_OUT
-    { TIM3, IO_TAG(PB1), TIM_Channel_4, TIM3_IRQn,          1, IOCFG_AF_PP, GPIO_AF_TIM3 },          // S3_OUT
-    { TIM2, IO_TAG(PA2), TIM_Channel_3, TIM2_IRQn,          1, IOCFG_AF_PP, GPIO_AF_TIM2 },          // S4_OUT
+    { TIM8, IO_TAG(PC9), TIM_Channel_4, TIM8_CC_IRQn,       0, IOCFG_AF_PP, GPIO_AF_TIM8, NULL,         0,             0  },          // PPM_IN
+
+    { TIM2,  IO_TAG(PA3),  TIM_Channel_4, TIM2_IRQn,        1, IOCFG_AF_PP, GPIO_AF_TIM2,  DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER  },  // S1_OUT
+    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,        1, IOCFG_AF_PP, GPIO_AF_TIM3,  DMA1_Stream7, DMA_Channel_5, DMA1_ST7_HANDLER  },  // S2_OUT
+    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,        1, IOCFG_AF_PP, GPIO_AF_TIM3,  DMA1_Stream2, DMA_Channel_5, DMA1_ST2_HANDLER  },  // S3_OUT
+    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, TIM2_IRQn,        1, IOCFG_AF_PP, GPIO_AF_TIM2,  DMA1_Stream1, DMA_Channel_3, DMA1_ST1_HANDLER  },  // S4_OUT
 
 //  { TIM5, GPIOA, Pin_0, TIM_Channel_1, TIM5_IRQn, 1, GPIO_Mode_AF, GPIO_PinSource0, GPIO_AF_TIM5 },    // LED Strip
 };

--- a/src/main/target/FURYF4/target.h
+++ b/src/main/target/FURYF4/target.h
@@ -183,11 +183,13 @@
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
+#define USE_DSHOT
+
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
 
 #define USABLE_TIMER_CHANNEL_COUNT 5
-#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(8) | TIM_N(9))
+#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(8) )
 

--- a/src/main/target/FURYF4/target.mk
+++ b/src/main/target/FURYF4/target.mk
@@ -6,5 +6,6 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu6500.c \
             drivers/accgyro_mpu6500.c \
             drivers/accgyro_spi_icm20689.c \
-            drivers/barometer_ms5611.c
+            drivers/barometer_ms5611.c \
+            drivers/pwm_output_stm32f4xx.c
 


### PR DESCRIPTION
FuryF3 and F4 DShot Implementation.  Don't have any Kiss ESCs so cannot test yet.  Used Logic analyzer and scope to check outputs.

FuryF4:  Works as advertised on the scope and analyzer.  

FuryF3:  Oneshot125, Oneshot42 and Multishot all look good across all 4 motor outputs.   DShot works on S4 out.  Nothing on S1-S3.  Spent several hours troubleshooting, but cannot figure out why.  Tried changing timers/DMA channels on a couple of outputs (S1-S3), but nothing works.  I then changed the output that works (S4) to the other Ch16 DMA Channel (6) and it stopped working.  

One last observation...protocol change in the configurator does not take effect until the board is power cycled.  Save/reboot changes the protocol, but the output stays on the last one selected until a power cycle happens.
