### PR TITLE
Dispatch handling

### DIFF
--- a/src/main/fc/fc_dispatch.h
+++ b/src/main/fc/fc_dispatch.h
@@ -17,15 +17,14 @@
 
 #pragma once
 
-typedef void (*dispatchFuncPtr)(void);
+struct dispatchEntry_s;
+typedef void dispatchFunc(struct dispatchEntry_s* self);
 
-typedef struct dispatchTask_s {
-    dispatchFuncPtr ptr;
-    uint16_t minimumDelayUs;
-
+typedef struct dispatchEntry_s {
+    dispatchFunc *dispatch;
     uint32_t delayedUntil;
-    struct dispatchTask_s *next;
-} dispatchTask_t;
+    struct dispatchEntry_s *next;
+} dispatchEntry_t;
 
 void dispatchProcess(uint32_t currentTime);
-void dispatchAdd(dispatchTask_t *task);
+void dispatchAdd(dispatchEntry_t *entry, int delayUs);


### PR DESCRIPTION
Slightly refactored the code

modified dispatch handling so that dispatchEntry can be easily included in struct (easy to implement parameters, without overhead)

Removed test for already queued entry. Zero delayedUntil is valid value, next is null even if item is queued. If queued entry test is desirable, it would be probably best to use some tricks from https://kernelnewbies.org/FAQ/LinkedLists (point to next entry and not structure/ point to self when entry is not inside list / use singly-linked circular list)

Another possibility is to copy linked lists from linux kernel - it is proven, well designed implementation and overhead of double link is not that bad.  It can be reused in other parts of code .. 


